### PR TITLE
Implement MkTable#delete()

### DIFF
--- a/src/main/java/com/jcabi/dynamo/mock/H2Data.java
+++ b/src/main/java/com/jcabi/dynamo/mock/H2Data.java
@@ -258,14 +258,13 @@ public final class H2Data implements MkData {
         }
     }
 
-
     /**
      * Delete attributes from the given table.
      * @todo 30min:#35 Implement H2Data#delete() method because MkData#delete
      *  method was added.
      * @param table Table name
      * @param keys Keys
-     * @throws IOException
+     * @throws IOException If fails
      */
     @Override
     public void delete(final String table, final Attributes keys)

--- a/src/main/java/com/jcabi/dynamo/mock/H2Data.java
+++ b/src/main/java/com/jcabi/dynamo/mock/H2Data.java
@@ -269,6 +269,7 @@ public final class H2Data implements MkData {
     @Override
     public void delete(final String table, final Attributes keys)
         throws IOException {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/main/java/com/jcabi/dynamo/mock/H2Data.java
+++ b/src/main/java/com/jcabi/dynamo/mock/H2Data.java
@@ -258,6 +258,12 @@ public final class H2Data implements MkData {
         }
     }
 
+    @Override
+    public void delete(String table, Attributes keys) throws IOException {
+        // @todo 30min:#35 Implement H2Data#delete() method because #delete
+        //  method was added to MkData interface.
+    }
+
     /**
      * With this table, that has given primary keys.
      * @param table Table name

--- a/src/main/java/com/jcabi/dynamo/mock/H2Data.java
+++ b/src/main/java/com/jcabi/dynamo/mock/H2Data.java
@@ -258,10 +258,18 @@ public final class H2Data implements MkData {
         }
     }
 
+
+    /**
+     * Delete attributes from the given table.
+     * @todo 30min:#35 Implement H2Data#delete() method because MkData#delete
+     *  method was added.
+     * @param table Table name
+     * @param keys Keys
+     * @throws IOException
+     */
     @Override
-    public void delete(String table, Attributes keys) throws IOException {
-        // @todo 30min:#35 Implement H2Data#delete() method because #delete
-        //  method was added to MkData interface.
+    public void delete(final String table, final Attributes keys)
+        throws IOException {
     }
 
     /**

--- a/src/main/java/com/jcabi/dynamo/mock/H2Data.java
+++ b/src/main/java/com/jcabi/dynamo/mock/H2Data.java
@@ -260,7 +260,7 @@ public final class H2Data implements MkData {
 
     /**
      * Delete attributes from the given table.
-     * @todo 30min:#35 Implement H2Data#delete() method because MkData#delete
+     * @todo #35:30min Implement H2Data#delete() method because MkData#delete
      *  method was added.
      * @param table Table name
      * @param keys Keys

--- a/src/main/java/com/jcabi/dynamo/mock/MkData.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkData.java
@@ -77,6 +77,7 @@ public interface MkData {
      * Delete attributes from the given table.
      * @param table Table name
      * @param keys Keys
+     * @throws IOException If fails
      */
     void delete(String table, Attributes keys) throws IOException;
 }

--- a/src/main/java/com/jcabi/dynamo/mock/MkData.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkData.java
@@ -73,4 +73,10 @@ public interface MkData {
     void update(String table, Attributes keys,
         AttributeUpdates attrs) throws IOException;
 
+    /**
+     * Delete attributes from the given table.
+     * @param table Table name
+     * @param keys Keys
+     */
+    void delete(String table, Attributes keys) throws IOException;
 }

--- a/src/main/java/com/jcabi/dynamo/mock/MkTable.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkTable.java
@@ -101,13 +101,6 @@ final class MkTable implements Table {
         return this.self;
     }
 
-    /**
-     * Delete item from aws table.
-     * @todo #8 Implement MkTable.delete() operation. delete() method added
-     *  to Table interface and implemented in AwsTable class so far.
-     * @param attributes Attributes
-     * @throws IOException In case of DynamoDB failure
-     */
     @Override
     public void delete(final Map<String, AttributeValue> attributes)
         throws IOException {

--- a/src/main/java/com/jcabi/dynamo/mock/MkTable.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkTable.java
@@ -111,6 +111,9 @@ final class MkTable implements Table {
     @Override
     public void delete(final Map<String, AttributeValue> attributes)
         throws IOException {
-        throw new UnsupportedOperationException();
+        this.data.delete(
+            this.self,
+            new Attributes(attributes)
+        );
     }
 }

--- a/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
+++ b/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
@@ -31,10 +31,12 @@ package com.jcabi.dynamo.mock;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import com.jcabi.dynamo.Attributes;
 import com.jcabi.dynamo.Conditions;
 import java.io.File;
 import java.util.Collections;
+import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -86,7 +88,8 @@ public final class H2DataTest {
     /**
      * H2Data can store to a file.
      * @throws Exception If some problem inside
-     * @see https://code.google.com/p/h2database/issues/detail?id=447
+     * @see <a href="https://code.google.com/p/h2database/issues/detail?id=447">
+     *  Google Code: DB file extension customizability</a>
      */
     @Test
     @Ignore
@@ -124,7 +127,7 @@ public final class H2DataTest {
             .with(
                 //@checkstyle MagicNumberCheck (1 line)
                 Joiner.on("").join(Collections.nCopies(255, "a")),
-                new String[] {"key"}, new String[0]
+                new String[]{"key"}, new String[0]
         );
     }
 
@@ -155,4 +158,37 @@ public final class H2DataTest {
         ).put(table, new Attributes().with(key, "value"));
     }
 
+    /**
+     * H2Data can delete records.
+     * @throws Exception In case test fails
+     */
+    @Test
+    public void deletesRecords() throws Exception {
+        final String table = "customers";
+        final String field = "name";
+        final String man = "Kevin";
+        final String woman = "Helen";
+        final H2Data data = new H2Data()
+            .with(table, new String[]{field}, new String[0]);
+        data.put(
+            table,
+            new Attributes().with(field, man)
+        );
+        data.put(
+            table,
+            new Attributes().with(field, woman)
+        );
+        data.delete(table, new Attributes().with(field, man));
+        final List<Attributes> rest = Lists.newArrayList(
+            data.iterate(table, new Conditions())
+        );
+        MatcherAssert.assertThat(
+            rest.size(),
+            Matchers.equalTo(1)
+        );
+        MatcherAssert.assertThat(
+            rest.get(0).get(field).getS(),
+            Matchers.equalTo(woman)
+        );
+    }
 }


### PR DESCRIPTION
I had to implement method `MkTable#delete()`. 

In order to do so, I:
- created a new method `MkData#delete`;
- added a puzzle in `H2Data` to implement `H2Data#delete()` because it implements `MkData`.

Fixes #35