### PR TITLE
#49 Refactoring MkData to eliminate table name.

### DIFF
--- a/src/main/java/com/jcabi/dynamo/mock/MkData.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkData.java
@@ -52,8 +52,7 @@ public interface MkData {
      * @return All rows found
      * @throws IOException If fails
      */
-    Iterable<Attributes> iterate(String table, Conditions conds)
-        throws IOException;
+    Iterable<Attributes> iterate(Conditions conds) throws IOException;
 
     /**
      * Add new attribute into the given table.
@@ -61,7 +60,7 @@ public interface MkData {
      * @param attrs Attributes to save
      * @throws IOException If fails
      */
-    void put(String table, Attributes attrs) throws IOException;
+    void put(Attributes attrs) throws IOException;
 
     /**
      * Add new attribute into the given table.
@@ -70,7 +69,6 @@ public interface MkData {
      * @param attrs Attributes to save
      * @throws IOException If fails
      */
-    void update(String table, Attributes keys,
-        AttributeUpdates attrs) throws IOException;
+    void update(Attributes keys, AttributeUpdates attrs) throws IOException;
 
 }

--- a/src/main/java/com/jcabi/dynamo/mock/MkData.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkData.java
@@ -47,7 +47,6 @@ public interface MkData {
 
     /**
      * Iterate everything for the given table.
-     * @param table Name of the table
      * @param conds Conditions
      * @return All rows found
      * @throws IOException If fails
@@ -56,7 +55,6 @@ public interface MkData {
 
     /**
      * Add new attribute into the given table.
-     * @param table Table name
      * @param attrs Attributes to save
      * @throws IOException If fails
      */
@@ -64,7 +62,6 @@ public interface MkData {
 
     /**
      * Add new attribute into the given table.
-     * @param table Table name
      * @param keys Keys
      * @param attrs Attributes to save
      * @throws IOException If fails

--- a/src/main/java/com/jcabi/dynamo/mock/MkFrame.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkFrame.java
@@ -102,7 +102,7 @@ final class MkFrame extends AbstractCollection<Item> implements Frame {
     public Iterator<Item> iterator() {
         try {
             return Iterators.transform(
-                this.data.iterate(this.tbl, this.conds).iterator(),
+                this.data.iterate(this.conds).iterator(),
                 new Function<Attributes, Item>() {
                     @Override
                     public Item apply(final Attributes input) {

--- a/src/main/java/com/jcabi/dynamo/mock/MkItem.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkItem.java
@@ -109,7 +109,7 @@ final class MkItem implements Item {
         final Map<String, AttributeValueUpdate> attrs) {
         try {
             this.data.update(
-                this.table, this.coords, new AttributeUpdates(attrs)
+                this.coords, new AttributeUpdates(attrs)
             );
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);

--- a/src/main/java/com/jcabi/dynamo/mock/MkTable.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkTable.java
@@ -79,7 +79,7 @@ final class MkTable implements Table {
     public Item put(final Map<String, AttributeValue> attributes) {
         final Attributes attrs = new Attributes(attributes);
         try {
-            this.data.put(this.self, attrs);
+            this.data.put(attrs);
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }

--- a/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
+++ b/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
@@ -68,13 +68,13 @@ public final class H2DataTest {
         final int number = 43;
         final String attr = "description";
         final String value = "some\n\t\u20ac text";
-        final MkData data = new H2Data().with(
-            table, new String[] {key}, new String[] {attr}
+        final MkData data = new H2Data(table).with(
+            new String[] {key}, new String[] {attr}
         );
-        data.put(table, new Attributes().with(key, number).with(attr, value));
+        data.put(new Attributes().with(key, number).with(attr, value));
         MatcherAssert.assertThat(
             data.iterate(
-                table, new Conditions().with(key, Conditions.equalTo(number))
+                new Conditions().with(key, Conditions.equalTo(number))
             ).iterator().next(),
             Matchers.hasEntry(
                 Matchers.equalTo(attr),
@@ -94,23 +94,26 @@ public final class H2DataTest {
         final File file = this.temp.newFile();
         final String table = "tbl";
         final String key = "key1";
-        final MkData data = new H2Data(file).with(
-            table, new String[] {key}, new String[0]
+        final MkData data = new H2Data(table, file).with(
+            new String[] {key}, new String[0]
         );
-        data.put(table, new Attributes().with(key, "x2"));
+        data.put(new Attributes().with(key, "x2"));
         MatcherAssert.assertThat(file.exists(), Matchers.is(true));
         MatcherAssert.assertThat(file.length(), Matchers.greaterThan(0L));
     }
 
     /**
-     * H2Data can create many tables.
+     * H2Data can create many tables. This test is suspended as
+     * with {@link MkData} definition now represents the underlining
+     * data of a table instead of a database. 
      * @throws Exception If some problem inside
      */
     @Test
+    @Ignore
     public void createsManyTables() throws Exception {
-        new H2Data()
-            .with("firsttable", new String[] {"firstid"}, new String[0])
-            .with("secondtable", new String[]{"secondid"}, new String[0]);
+        new H2Data("firsttable")
+            .with(new String[] {"firstid"}, new String[0])
+            .with(new String[]{"secondid"}, new String[0]);
     }
 
     /**
@@ -120,12 +123,9 @@ public final class H2DataTest {
      */
     @Test
     public void createsTablesWithLongNames() throws Exception {
-        new H2Data()
-            .with(
-                //@checkstyle MagicNumberCheck (1 line)
-                Joiner.on("").join(Collections.nCopies(255, "a")),
-                new String[] {"key"}, new String[0]
-        );
+        //@checkstyle MagicNumberCheck (1 line)
+        new H2Data(Joiner.on("").join(Collections.nCopies(255, "a")))
+            .with(new String[] {"key"}, new String[0]);
     }
 
     /**
@@ -134,7 +134,7 @@ public final class H2DataTest {
      */
     @Test
     public void supportsTableNamesWithIllegalCharacters() throws Exception {
-        new H2Data().with(".-.", new String[]{"pk"}, new String[0]);
+        new H2Data(".-.").with(new String[]{"pk"}, new String[0]);
     }
 
     /**
@@ -150,9 +150,9 @@ public final class H2DataTest {
     public void supportsColumnNamesWithIllegalCharacters() throws Exception {
         final String key = "0-.col.-0";
         final String table = "test";
-        new H2Data().with(
-            table, new String[] {key}, new String[0]
-        ).put(table, new Attributes().with(key, "value"));
+        new H2Data(table).with(
+            new String[] {key}, new String[0]
+        ).put(new Attributes().with(key, "value"));
     }
 
 }

--- a/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
+++ b/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
@@ -106,7 +106,7 @@ public final class H2DataTest {
     /**
      * H2Data can create many tables. This test is suspended as
      * with {@link MkData} definition now represents the underlining
-     * data of a table instead of a database. 
+     * data of a table instead of a database.
      * @throws Exception If some problem inside
      */
     @Test

--- a/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
+++ b/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
@@ -168,17 +168,16 @@ public final class H2DataTest {
         final String attr = "desc";
         final String value = "Dummy\n\t\u20ac text";
         final String updated = "Updated";
-        final MkData data = new H2Data().with(
-            table, new String[] {key}, new String[] {attr}
+        final MkData data = new H2Data(table).with(
+            new String[] {key}, new String[] {attr}
         );
-        data.put(table, new Attributes().with(key, number).with(attr, value));
+        data.put(new Attributes().with(key, number).with(attr, value));
         data.update(
-            table,
             new Attributes().with(key, number),
             new AttributeUpdates().with(attr, updated)
         );
         final Iterable<Attributes> result = data.iterate(
-            table, new Conditions().with(key, Conditions.equalTo(number))
+            new Conditions().with(key, Conditions.equalTo(number))
         );
         MatcherAssert.assertThat(
             result.iterator().next(),

--- a/src/test/java/com/jcabi/dynamo/mock/MkRegionTest.java
+++ b/src/test/java/com/jcabi/dynamo/mock/MkRegionTest.java
@@ -55,7 +55,7 @@ public final class MkRegionTest {
         final String key = "id";
         final String attr = "description";
         final Region region = new MkRegion(
-            new H2Data().with(name, new String[] {key}, new String[] {attr})
+            new H2Data(name).with(new String[] {key}, new String[] {attr})
         );
         final Table table = region.table(name);
         final AttributeValue value = new AttributeValue("some\n\t\u20ac text");


### PR DESCRIPTION
For task #49 

- Refactor `MkData` to eliminate table name in all methods.
- Modified `H2Data` implementation for the interface changes
- Modified unit tests.