### PR TITLE
#80: fix AttributeUpdates.containsValue(Object)

### DIFF
--- a/src/main/java/com/jcabi/dynamo/AttributeUpdates.java
+++ b/src/main/java/com/jcabi/dynamo/AttributeUpdates.java
@@ -95,13 +95,9 @@ public final class AttributeUpdates
      * @since 0.14.3
      */
     public AttributeUpdates with(final String name, final Object value) {
-        final AttributeValue attr;
-        if (value instanceof Long || value instanceof Integer) {
-            attr = AttributeValue.builder().n(value.toString()).build();
-        } else {
-            attr = AttributeValue.builder().s(value.toString()).build();
-        }
-        return this.with(name, attr);
+        return new AttributeUpdates(
+            this.attrs.with(name, AttributeUpdates.toUpdate(value))
+        );
     }
 
     /**
@@ -150,7 +146,7 @@ public final class AttributeUpdates
 
     @Override
     public boolean containsValue(final Object value) {
-        return this.attrs.containsValue(value);
+        return this.attrs.containsValue(AttributeUpdates.toUpdate(value));
     }
 
     @Override
@@ -201,5 +197,41 @@ public final class AttributeUpdates
         throw new UnsupportedOperationException(
             "AttributeUpdates class is immutable, can't do #clear()"
         );
+    }
+
+    /**
+     * Convert any input value to an {@link AttributeValueUpdate}.
+     *
+     * <p>If the value is already an {@link AttributeValueUpdate}, it is
+     * returned as-is. If it is an {@link AttributeValue}, it is wrapped
+     * with a {@link AttributeAction#PUT} action. Numeric values are
+     * stored as {@code n}, anything else as {@code s} via
+     * {@link Object#toString()}.
+     *
+     * @param value The value to convert
+     * @return The converted {@link AttributeValueUpdate}
+     */
+    private static AttributeValueUpdate toUpdate(final Object value) {
+        final AttributeValueUpdate result;
+        if (value instanceof AttributeValueUpdate) {
+            result = (AttributeValueUpdate) value;
+        } else if (value instanceof AttributeValue) {
+            result = AttributeValueUpdate.builder()
+                .value((AttributeValue) value)
+                .action(AttributeAction.PUT)
+                .build();
+        } else {
+            final AttributeValue attr;
+            if (value instanceof Long || value instanceof Integer) {
+                attr = AttributeValue.builder().n(value.toString()).build();
+            } else {
+                attr = AttributeValue.builder().s(value.toString()).build();
+            }
+            result = AttributeValueUpdate.builder()
+                .value(attr)
+                .action(AttributeAction.PUT)
+                .build();
+        }
+        return result;
     }
 }

--- a/src/test/java/com/jcabi/dynamo/AttributeUpdatesTest.java
+++ b/src/test/java/com/jcabi/dynamo/AttributeUpdatesTest.java
@@ -187,6 +187,55 @@ final class AttributeUpdatesTest {
     }
 
     @Test
+    void containsObjectValue() {
+        final String value = "someString";
+        MatcherAssert.assertThat(
+            "should contain raw object value 'someString'",
+            new AttributeUpdates()
+                .with("attrkey", value)
+                .with("otherkey", "othervalue")
+                .containsValue(value),
+            Matchers.is(Boolean.TRUE)
+        );
+    }
+
+    @Test
+    void containsNumericObjectValue() {
+        final long value = 42L;
+        MatcherAssert.assertThat(
+            "should contain raw numeric value 42",
+            new AttributeUpdates()
+                .with("nkey", value)
+                .containsValue(value),
+            Matchers.is(Boolean.TRUE)
+        );
+    }
+
+    @Test
+    void containsAttributeValue() {
+        final AttributeValue value =
+            AttributeValue.builder().s("attrValue").build();
+        MatcherAssert.assertThat(
+            "should contain AttributeValue",
+            new AttributeUpdates()
+                .with("attrkey", value)
+                .containsValue(value),
+            Matchers.is(Boolean.TRUE)
+        );
+    }
+
+    @Test
+    void doesNotContainMissingValue() {
+        MatcherAssert.assertThat(
+            "should not contain missing value",
+            new AttributeUpdates()
+                .with("attrkey", "present")
+                .containsValue("absent"),
+            Matchers.is(Boolean.FALSE)
+        );
+    }
+
+    @Test
     void canTurnToString() {
         MatcherAssert.assertThat(
             "should contain key names",


### PR DESCRIPTION
@yegor256, this fixes #80.

## What

- Two commits: a regression test commit, then the fix.
- `AttributeUpdates.containsValue(Object)` now applies the same conversion as `with(String, Object)` before delegating to the inner `attrs` map.
- The conversion is centralised in a private `toUpdate(Object)` helper used by both `with(String, Object)` and `containsValue`, so the wrapping rules live in one place.
- `containsValue` now also handles raw `AttributeValue` arguments (wraps them with `PUT`) and still accepts a fully-built `AttributeValueUpdate` unchanged.

## Why

`with(String, Object)` wraps the input value into an `AttributeValueUpdate` with action `PUT` before storing it. The old `containsValue` passed the raw argument straight to `attrs.containsValue`, so the simple natural form `attrs.with("k", "v").containsValue("v")` always returned `false`. The original ticket noted the existing `containsValue` test had to construct the full `AttributeValueUpdate` to work around this.

## Tests

New tests in `AttributeUpdatesTest` (each fails on `master`, passes on this branch):
- `containsObjectValue` — raw `String` argument
- `containsNumericObjectValue` — raw `Long` argument
- `containsAttributeValue` — `AttributeValue` argument
- `doesNotContainMissingValue` — negative case

The pre-existing `containsValue` test (which builds the full `AttributeValueUpdate`) still passes.

## Build

`mvn --batch-mode clean install -Pqulice` is green locally on JDK 21 (Linux). The PR's GitHub Actions runs are sitting in `action_required` because I'm a first-time contributor to this repo — ready for approval whenever you have a moment.