### PR TITLE
Fix composite primary key creation in H2Data.with() (#95)

### DIFF
--- a/src/main/java/com/jcabi/dynamo/mock/H2Data.java
+++ b/src/main/java/com/jcabi/dynamo/mock/H2Data.java
@@ -129,10 +129,16 @@ public final class H2Data implements MkData {
     };
 
     /**
-     * Create primary key.
+     * Declare a key column.
      */
     private static final Function<String, String> CREATE_KEY =
-        key -> String.format("`%s` VARCHAR PRIMARY KEY", key);
+        key -> String.format("`%s` VARCHAR NOT NULL", key);
+
+    /**
+     * Quote a key column name for use inside a PRIMARY KEY clause.
+     */
+    private static final Function<String, String> QUOTE_KEY =
+        key -> String.format("`%s`", key);
 
     /**
      * Create attr.
@@ -311,7 +317,8 @@ public final class H2Data implements MkData {
                 String.format("Empty list of keys for %s table", table)
             );
         }
-        final StringBuilder sql = new StringBuilder("CREATE TABLE ")
+        final StringBuilder sql = new StringBuilder(128)
+            .append("CREATE TABLE ")
             .append(H2Data.encodeTableName(table)).append(" (");
         Joiner.on(',').appendTo(
             sql,
@@ -324,7 +331,12 @@ public final class H2Data implements MkData {
                 Iterables.transform(Arrays.asList(attrs), H2Data.CREATE_ATTR)
             );
         }
-        sql.append(')');
+        sql.append(", PRIMARY KEY (");
+        Joiner.on(',').appendTo(
+            sql,
+            Iterables.transform(Arrays.asList(keys), H2Data.QUOTE_KEY)
+        );
+        sql.append("))");
         try {
             new JdbcSession(this.jdbc).sql(sql.toString()).execute();
         } catch (final SQLException ex) {

--- a/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
+++ b/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
@@ -69,6 +69,44 @@ final class H2DataTest {
     }
 
     @Test
+    void createsTableWithCompositePrimaryKey() throws Exception {
+        final String table = "events";
+        final String hash = "device";
+        final String range = "moment";
+        final String attr = "payload";
+        final MkData data = new H2Data().with(
+            table, new String[] {hash, range}, attr
+        );
+        data.put(
+            table,
+            new Attributes()
+                .with(hash, "device-1")
+                .with(range, "1")
+                .with(attr, "first")
+        );
+        data.put(
+            table,
+            new Attributes()
+                .with(hash, "device-1")
+                .with(range, "2")
+                .with(attr, "second")
+        );
+        MatcherAssert.assertThat(
+            "should fetch the row by composite key",
+            data.iterate(
+                table,
+                new Conditions()
+                    .with(hash, Conditions.equalTo("device-1"))
+                    .with(range, Conditions.equalTo("2"))
+            ).iterator().next(),
+            Matchers.hasEntry(
+                Matchers.equalTo(attr),
+                Matchers.equalTo(AttributeValue.builder().s("second").build())
+            )
+        );
+    }
+
+    @Test
     void createsManyTables() throws Exception {
         MatcherAssert.assertThat(
             "should create two tables",

--- a/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
+++ b/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.dynamodb.model.Condition;
  * Test case for {@link H2Data}.
  * @since 0.10
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class H2DataTest {
 
     @Test


### PR DESCRIPTION
@yegor256 fixes #95.

## What was wrong

`H2Data.with(table, new String[]{"hash", "range"}, ...)` produced invalid SQL:

```sql
CREATE TABLE _XXX (`hash` VARCHAR PRIMARY KEY, `range` VARCHAR PRIMARY KEY, `attr` CLOB)
```

H2 rejects this with `org.h2.jdbc.JdbcSQLSyntaxErrorException: Attempt to define a second primary key`, so any DynamoDB-style table with a hash + range key was unusable in the H2-backed mock.

## What this PR does

Two commits:

1. **Reproduce the bug** — `H2DataTest#createsTableWithCompositePrimaryKey` calls `H2Data.with(table, new String[]{hash, range}, attr)` and asserts that two rows can be inserted and retrieved by composite key. On `master` it fails with the H2 error above.
2. **Fix `H2Data.with()`** — emit each key column as `` `col` VARCHAR NOT NULL `` and append a single composite `PRIMARY KEY (k1, k2, ...)` constraint at the end of the column list. Single-key tables still produce one PRIMARY KEY clause, so every pre-existing `H2DataTest` case keeps passing.

## Verification

- New test fails on `master`, passes on this branch.
- Full `mvn clean install -Pqulice` is green locally.
- All 14 CI checks are green: linters (`actionlint`, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`) and the full `mvn` matrix on `ubuntu-24.04`, `macos-15`, `windows-2022` × Java 17 & 21.

Ready for merge.