### PR TITLE
#53 Add direct unit tests for AwsTable#keys()

### DIFF
--- a/src/test/java/com/jcabi/dynamo/AwsTableTest.java
+++ b/src/test/java/com/jcabi/dynamo/AwsTableTest.java
@@ -4,10 +4,13 @@
  */
 package com.jcabi.dynamo;
 
+import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity;
@@ -154,5 +157,39 @@ final class AwsTableTest {
         Mockito.verify(aws).describeTable(
             DescribeTableRequest.builder().tableName(name).build()
         );
+    }
+
+    @Test
+    void wrapsSdkClientExceptionAsIoException() {
+        final Credentials credentials = Mockito.mock(Credentials.class);
+        final DynamoDbClient aws = Mockito.mock(DynamoDbClient.class);
+        Mockito.doReturn(aws).when(credentials).aws();
+        Mockito.doThrow(SdkClientException.builder().message("boom").build())
+            .when(aws).describeTable(Mockito.any(DescribeTableRequest.class));
+        Assertions.assertThrows(
+            IOException.class,
+            new AwsTable(
+                credentials, Mockito.mock(Region.class), "broken-table"
+            )::keys,
+            "keys() must rethrow SdkClientException wrapped as IOException"
+        );
+    }
+
+    @Test
+    void closesDynamoDbClientAfterDescribe() throws Exception {
+        final Credentials credentials = Mockito.mock(Credentials.class);
+        final DynamoDbClient aws = Mockito.mock(DynamoDbClient.class);
+        Mockito.doReturn(aws).when(credentials).aws();
+        Mockito.doReturn(
+            DescribeTableResponse.builder().table(
+                TableDescription.builder().keySchema(
+                    KeySchemaElement.builder().attributeName(AwsTableTest.KEY).build()
+                ).build()
+            ).build()
+        ).when(aws).describeTable(Mockito.any(DescribeTableRequest.class));
+        new AwsTable(
+            credentials, Mockito.mock(Region.class), "closed-table"
+        ).keys();
+        Mockito.verify(aws).close();
     }
 }

--- a/src/test/java/com/jcabi/dynamo/AwsTableTest.java
+++ b/src/test/java/com/jcabi/dynamo/AwsTableTest.java
@@ -4,6 +4,8 @@
  */
 package com.jcabi.dynamo;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -85,5 +87,72 @@ final class AwsTableTest {
             )
         );
         Mockito.verify(aws).deleteItem(Mockito.any(DeleteItemRequest.class));
+    }
+
+    @Test
+    void returnsKeysFromDescribeTable() throws Exception {
+        final Credentials credentials = Mockito.mock(Credentials.class);
+        final DynamoDbClient aws = Mockito.mock(DynamoDbClient.class);
+        Mockito.doReturn(aws).when(credentials).aws();
+        Mockito.doReturn(
+            DescribeTableResponse.builder().table(
+                TableDescription.builder().keySchema(
+                    KeySchemaElement.builder().attributeName(AwsTableTest.KEY).build()
+                ).build()
+            ).build()
+        ).when(aws).describeTable(Mockito.any(DescribeTableRequest.class));
+        final AwsTable table = new AwsTable(
+            credentials, Mockito.mock(Region.class), "table-with-key"
+        );
+        MatcherAssert.assertThat(
+            "keys() must return the single primary key declared in the table schema",
+            table.keys(),
+            Matchers.contains(AwsTableTest.KEY)
+        );
+    }
+
+    @Test
+    void returnsCompositeKeysInDeclaredOrder() throws Exception {
+        final Credentials credentials = Mockito.mock(Credentials.class);
+        final DynamoDbClient aws = Mockito.mock(DynamoDbClient.class);
+        Mockito.doReturn(aws).when(credentials).aws();
+        Mockito.doReturn(
+            DescribeTableResponse.builder().table(
+                TableDescription.builder().keySchema(
+                    KeySchemaElement.builder().attributeName("hash-key").build(),
+                    KeySchemaElement.builder().attributeName("range-key").build()
+                ).build()
+            ).build()
+        ).when(aws).describeTable(Mockito.any(DescribeTableRequest.class));
+        final AwsTable table = new AwsTable(
+            credentials, Mockito.mock(Region.class), "composite-table"
+        );
+        MatcherAssert.assertThat(
+            "keys() must preserve the order of the composite primary key",
+            table.keys(),
+            Matchers.contains("hash-key", "range-key")
+        );
+    }
+
+    @Test
+    void requestsDescribeForOwnTable() throws Exception {
+        final Credentials credentials = Mockito.mock(Credentials.class);
+        final DynamoDbClient aws = Mockito.mock(DynamoDbClient.class);
+        Mockito.doReturn(aws).when(credentials).aws();
+        Mockito.doReturn(
+            DescribeTableResponse.builder().table(
+                TableDescription.builder().keySchema(
+                    KeySchemaElement.builder().attributeName(AwsTableTest.KEY).build()
+                ).build()
+            ).build()
+        ).when(aws).describeTable(Mockito.any(DescribeTableRequest.class));
+        final String name = "my-described-table";
+        final AwsTable table = new AwsTable(
+            credentials, Mockito.mock(Region.class), name
+        );
+        table.keys();
+        Mockito.verify(aws).describeTable(
+            DescribeTableRequest.builder().tableName(name).build()
+        );
     }
 }


### PR DESCRIPTION
@yegor256 this PR resolves #53 by adding direct unit tests for `AwsTable#keys()`, which previously had none.

## Why

Issue #53 reported that `AwsTable#keys()` is not covered by unit tests. The class did have an `AwsTableTest`, but its two tests (`savesItemToDynamo` and `deletesItemFromDynamo`) only invoked `keys()` indirectly inside `put()` and never asserted on the returned collection or on how `describeTable` was invoked, so a regression in `keys()` could pass silently.

## What changed

Five new tests are added to `AwsTableTest`, structured as two commits:

- **be91291** — happy-path coverage:
  - `returnsKeysFromDescribeTable` — single primary key returned correctly
  - `returnsCompositeKeysInDeclaredOrder` — composite (hash + range) primary key returned in declared order
  - `requestsDescribeForOwnTable` — `describeTable` is invoked with the table name supplied to the constructor
- **45117a1** — error and cleanup paths:
  - `wrapsSdkClientExceptionAsIoException` — `SdkClientException` from `describeTable` is rethrown as `IOException`
  - `closesDynamoDbClientAfterDescribe` — the `DynamoDbClient` returned from `credentials.aws()` is closed in the success path

No production code is changed. `keys()` already behaves correctly; the missing piece was the test coverage that the issue called out.

## Verification

All 14 CI checks are green: `mvn` on `ubuntu-24.04`, `macos-15`, `windows-2022` × Java `17` and `21`, plus `actionlint`, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`. Locally `mvn -Pqulice clean install` (qulice 0.25.1) is also clean.