### PR TITLE
Fix #47: clarify Javadoc for MkData.put() and update()

### DIFF
--- a/src/main/java/com/jcabi/dynamo/mock/MkData.java
+++ b/src/main/java/com/jcabi/dynamo/mock/MkData.java
@@ -37,18 +37,20 @@ public interface MkData {
         throws IOException;
 
     /**
-     * Add new attribute into the given table.
+     * Insert a new item into the given table.
      * @param table Table name
-     * @param attrs Attributes to save
+     * @param attrs Full set of attributes that form the new item
      * @throws IOException If fails
      */
     void put(String table, Attributes attrs) throws IOException;
 
     /**
-     * Add new attribute into the given table.
+     * Update attributes of an existing item in the given table.
+     * Unlike {@link #put}, this method does not insert a new item; it only
+     * modifies attribute values of the item already identified by {@code keys}.
      * @param table Table name
-     * @param keys Keys
-     * @param attrs Attributes to save
+     * @param keys Primary key attributes that identify the item to update
+     * @param attrs Attribute changes to apply to the identified item
      * @throws IOException If fails
      */
     void update(String table, Attributes keys,

--- a/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
+++ b/src/test/java/com/jcabi/dynamo/mock/H2DataTest.java
@@ -247,6 +247,24 @@ final class H2DataTest {
     }
 
     @Test
+    void updateDoesNotInsertWhenKeyIsMissing() throws Exception {
+        final String table = "accounts";
+        final String key = "acct";
+        final String attr = "balance";
+        final MkData data = new H2Data().with(table, new String[]{key}, attr);
+        data.update(
+            table,
+            new Attributes().with(key, "ghost"),
+            new AttributeUpdates().with(attr, "100")
+        );
+        MatcherAssert.assertThat(
+            "update with a key that does not exist must not insert a new row",
+            Lists.newArrayList(data.iterate(table, new Conditions())),
+            Matchers.empty()
+        );
+    }
+
+    @Test
     void fetchesWithComparison() throws Exception {
         final String table = "x12";
         final String key = "foo1";


### PR DESCRIPTION
Fixes #47.

Both `put()` and `update()` in `MkData` carried the same description ("Add new attribute into the given table"), making it impossible to tell from the docs alone what each method does or when to use one vs the other. The `keys` parameter on `update()` was documented only as "Keys", with no explanation of its role.

This change rewrites the Javadoc for both methods: `put()` now says it inserts a new item, and `update()` explains it modifies an existing item identified by the primary key attributes supplied in `keys`, with an explicit cross-reference to `put()` to highlight the distinction. A test was also added to `H2DataTest` that verifies `update()` with an unknown key leaves the table empty, documenting the "no upsert" contract.